### PR TITLE
Fix for WPF Core3Win

### DIFF
--- a/Nuget/FastReport.Compat.targets
+++ b/Nuget/FastReport.Compat.targets
@@ -5,10 +5,13 @@
       <PropertyGroup Condition="'$(_MicrosoftNetSdkWindowsDesktop)' == ''">
         <_MicrosoftNetSdkWindowsDesktop>false</_MicrosoftNetSdkWindowsDesktop>
       </PropertyGroup>
-      <ItemGroup Condition="!$(_MicrosoftNetSdkWindowsDesktop)">
+      <PropertyGroup Condition="'$(UseWindowsForms)' == ''">
+        <UseWindowsForms>false</UseWindowsForms>
+      </PropertyGroup>
+      <ItemGroup Condition="!$(_MicrosoftNetSdkWindowsDesktop) Or !$(UseWindowsForms)">
         <Reference Include="$(MSBuildThisFileDirectory)lib\netcoreapp3.0\FastReport.Compat.dll" />
       </ItemGroup>
-      <ItemGroup Condition="$(_MicrosoftNetSdkWindowsDesktop)">
+      <ItemGroup Condition="$(_MicrosoftNetSdkWindowsDesktop) And $(UseWindowsForms)">
         <Reference Include="$(MSBuildThisFileDirectory)lib\netcoreapp3.0-Win\FastReport.Compat.dll" />
       </ItemGroup>
     </When>


### PR DESCRIPTION
Targets nuget package: If <UseWindowsForms> don't declared => include WinFormsReplacement